### PR TITLE
Fix database deserialization

### DIFF
--- a/convert_db.py
+++ b/convert_db.py
@@ -43,6 +43,7 @@ class CryptDatabase(object):
                 name_size = unpack('>I', f.read(4))[0]
                 name = unpack('{}s'.format(name_size), f.read(name_size))[0]
                 compressed = unpack('>b', f.read(1))[0] == b'\x01'
+                unknown_val = unpack('>I', f.read(4))[0]
                 buff_size = unpack('>I', f.read(4))[0]
                 buff = unpack('{}s'.format(buff_size), f.read(buff_size))[0]
                 if compressed:


### PR DESCRIPTION
The latest version of database.d3v appears to have an extra 4-byte field before the buff_size field, which was causing the script to fail. I don't know what the value represents, but this one-line change fixes the script. With this change, the FindCrypt plugin still appears to work well. 