### PR TITLE
ghidra 10.2 support

### DIFF
--- a/FindCrypt/src/main/java/findcrypt/FindCryptAnalyzer.java
+++ b/FindCrypt/src/main/java/findcrypt/FindCryptAnalyzer.java
@@ -28,7 +28,6 @@ import ghidra.program.model.address.Address;
 import ghidra.program.model.address.AddressSetView;
 import ghidra.program.model.data.ArrayDataType;
 import ghidra.program.model.data.ByteDataType;
-import ghidra.program.model.data.DataTypeConflictException;
 import ghidra.program.model.listing.Program;
 import ghidra.program.model.symbol.SourceType;
 import ghidra.program.model.util.CodeUnitInsertionException;
@@ -115,7 +114,7 @@ public class FindCryptAnalyzer extends AbstractAnalyzer {
 						
 						try {
 							program.getListing().createData(found_addr, dt);
-						} catch (CodeUnitInsertionException | DataTypeConflictException e) {
+						} catch (CodeUnitInsertionException e) {
 							// We failed to attach the datatype, this is probably due to existing data
 							// If that's the case, we probably don't want to overwrite it...
 							Msg.warn(this, "Could not apply datatype for crypt constant", e);


### PR DESCRIPTION
seems like they eliminated `DataTypeConflictException` in ghidra 10.2 in https://github.com/NationalSecurityAgency/ghidra/commit/01067debde726626efde19a397fb8334247b97e7